### PR TITLE
Update Dockerfile.prod to use npm ci instead of npm i

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
 COPY ./ ./
-RUN npm i
+RUN npm ci
 CMD ["npm", "run", "build"]
 
 FROM nginx:stable AS server

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
 COPY ./ ./
-RUN npm i
+RUN npm ci
 CMD ["npm", "run", "server:prod"]


### PR DESCRIPTION
I think this is probably what you want seeing as Dockerfile.dev was already using `npm ci`